### PR TITLE
feat: x-forwarded-prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ function absoluteUrl (options, req, res, next) {
       if ('x-forwarded-host' in this.headers) {
         host = this.headers['x-forwarded-host']
       }
+
+      if ('x-forwarded-prefix' in this.headers) {
+        absoluteUrl.pathname = absoluteUrl.pathname === '/'
+          ? this.headers['x-forwarded-prefix']
+          : path.join(this.headers['x-forwarded-prefix'], absoluteUrl.pathname)
+      }
     }
 
     if (!host) {


### PR DESCRIPTION
This PR adds support for `X-Forwarded-Prefix` header which may be added by proxies serving sub-paths

It simply concatenates the prefix with the resource path, with the exception of root (`/`) path which would be simply replaced with the prefix. In other words
